### PR TITLE
DX-1802: apply refresh to simple keys

### DIFF
--- a/src/components/databrowser/components/display/display-header.tsx
+++ b/src/components/databrowser/components/display/display-header.tsx
@@ -20,7 +20,7 @@ export const DisplayHeader = ({
   const { setSelectedListItem } = useDatabrowserStore()
 
   const handleAddItem = () => {
-    setSelectedListItem({ key: type === "stream" ? "*" : "", value: "", isNew: true })
+    setSelectedListItem({ key: type === "stream" ? "*" : "", isNew: true })
   }
 
   return (

--- a/src/components/databrowser/components/display/display-list.tsx
+++ b/src/components/databrowser/components/display/display-list.tsx
@@ -82,7 +82,7 @@ export const ListItems = ({
           data-item-key={key}
           data-item-value={value}
           onClick={() => {
-            setSelectedListItem({ key, value })
+            setSelectedListItem({ key })
           }}
           className="h-10 border-b border-b-zinc-100 hover:bg-zinc-50"
         >

--- a/src/components/databrowser/components/display/display-simple.tsx
+++ b/src/components/databrowser/components/display/display-simple.tsx
@@ -45,9 +45,6 @@ const EditorDisplayForm = ({
   const form = useForm({
     defaultValues: { value: data },
   })
-  const { editor, selector } = useField({ name: "value", form })
-
-  const { mutateAsync: setKey, isPending: isSettingKey } = useSetSimpleKey(dataKey, type)
 
   // Updates default values after submit
   useEffect(() => {
@@ -58,6 +55,10 @@ const EditorDisplayForm = ({
       }
     )
   }, [data])
+
+  const { editor, selector } = useField({ name: "value", form, data })
+
+  const { mutateAsync: setKey, isPending: isSettingKey } = useSetSimpleKey(dataKey, type)
 
   const handleCancel = () => {
     form.reset()

--- a/src/components/databrowser/components/display/display-simple.tsx
+++ b/src/components/databrowser/components/display/display-simple.tsx
@@ -54,7 +54,7 @@ const EditorDisplayForm = ({
     form.reset(
       { value: data },
       {
-        keepValues: true,
+        keepValues: false,
       }
     )
   }, [data])

--- a/src/components/databrowser/components/display/input/use-field.tsx
+++ b/src/components/databrowser/components/display/input/use-field.tsx
@@ -10,12 +10,14 @@ export const useField = ({
   height,
   showCopyButton,
   readOnly,
+  data,
 }: {
   name: string
   form: UseFormReturn<any>
   height?: number
   showCopyButton?: boolean
   readOnly?: boolean
+  data?: string
 }) => {
   const { field, fieldState } = useController<Record<string, string>>({
     name,
@@ -26,7 +28,7 @@ export const useField = ({
     checkIsValidJSON(field.value) ? "JSON" : "Text"
   )
 
-  // Attempt to format JSON on initial load
+  // Attempt to format JSON everytime the underlying data changes
   useEffect(() => {
     if (!checkIsValidJSON(field.value)) {
       return
@@ -35,7 +37,7 @@ export const useField = ({
     form.setValue(name, formatJSON(field.value), {
       shouldDirty: false,
     })
-  }, [])
+  }, [data])
 
   const handleTypeChange = (type: ContentType) => {
     setContentType(type)

--- a/src/components/databrowser/components/display/input/use-field.tsx
+++ b/src/components/databrowser/components/display/input/use-field.tsx
@@ -17,7 +17,7 @@ export const useField = ({
   height?: number
   showCopyButton?: boolean
   readOnly?: boolean
-  data?: string
+  data: string
 }) => {
   const { field, fieldState } = useController<Record<string, string>>({
     name,
@@ -30,11 +30,11 @@ export const useField = ({
 
   // Attempt to format JSON everytime the underlying data changes
   useEffect(() => {
-    if (!checkIsValidJSON(field.value)) {
+    if (!checkIsValidJSON(data)) {
       return
     }
 
-    form.setValue(name, formatJSON(field.value), {
+    form.setValue(name, formatJSON(data), {
       shouldDirty: false,
     })
   }, [data])

--- a/src/components/databrowser/components/sidebar/index.tsx
+++ b/src/components/databrowser/components/sidebar/index.tsx
@@ -4,7 +4,7 @@ import { queryClient } from "@/lib/clients"
 import { Button } from "@/components/ui/button"
 import { Spinner } from "@/components/ui/spinner"
 
-import { FETCH_LIST_ITEMS_QUERY_KEY } from "../../hooks"
+import { FETCH_LIST_ITEMS_QUERY_KEY, FETCH_SIMPLE_KEY_QUERY_KEY } from "../../hooks"
 import { useKeys } from "../../hooks/use-keys"
 import { AddKeyModal } from "../add-key-modal"
 import { DisplayDbSize, FETCH_DB_SIZE_QUERY_KEY } from "./db-size"
@@ -31,6 +31,9 @@ export function Sidebar() {
                 refetch()
                 queryClient.invalidateQueries({
                   queryKey: [FETCH_LIST_ITEMS_QUERY_KEY],
+                })
+                queryClient.invalidateQueries({
+                  queryKey: [FETCH_SIMPLE_KEY_QUERY_KEY],
                 })
                 queryClient.invalidateQueries({
                   queryKey: [FETCH_DB_SIZE_QUERY_KEY],

--- a/src/components/databrowser/hooks/use-fetch-simple-key.tsx
+++ b/src/components/databrowser/hooks/use-fetch-simple-key.tsx
@@ -19,9 +19,26 @@ export const useFetchSimpleKey = (dataKey: string, type: DataType) => {
       else if (type === "json") result = (await redis.json.get(dataKey)) as string | null
       else throw new Error(`Invalid type when fetching simple key: ${type}`)
 
+      if (type === "json" && result !== null)
+        result = JSON.stringify(sortObject(JSON.parse(result)))
+
       if (result === null) deleteKeyCache(dataKey)
 
       return result
     },
   })
+}
+
+// Add recursive key sorting to a JSON object
+const sortObject = (obj: unknown): unknown => {
+  if (typeof obj !== "object" || obj === null) return obj
+  return Object.fromEntries(
+    Object.entries(obj)
+      .sort((a, b) => a[0].localeCompare(b[0]))
+      .map(([key, value]) =>
+        typeof value === "object" && !Array.isArray(value) && value !== null
+          ? [key, sortObject(value)]
+          : [key, value]
+      )
+  )
 }

--- a/src/store.tsx
+++ b/src/store.tsx
@@ -59,7 +59,6 @@ export type SearchFilter = {
 
 export type SelectedItem = {
   key: string
-  value?: string
   isNew?: boolean
 }
 
@@ -68,7 +67,7 @@ type DatabrowserStore = {
   setSelectedKey: (key: string | undefined) => void
 
   selectedListItem?: SelectedItem
-  setSelectedListItem: (item?: { key: string; value?: string; isNew?: boolean }) => void
+  setSelectedListItem: (item?: { key: string; isNew?: boolean }) => void
 
   search: SearchFilter
   setSearch: (search: SearchFilter) => void


### PR DESCRIPTION
When a simple key (string & json) is updated externally and the refresh button is clicked while that key is selected in the databrowser, it wouldn't refetch the key.

Added invalidation to refresh button to fix this.

Then, the key would be refetched. But it wouldn't be updated in the editor. Changed keepValues to false in order to fix this.