### PR TITLE
Disable pipelinening for key scanning and value getting

### DIFF
--- a/src/components/databrowser/hooks/use-fetch-keys.ts
+++ b/src/components/databrowser/hooks/use-fetch-keys.ts
@@ -10,7 +10,7 @@ const FETCH_COUNTS = [100, 200, 400, 800]
 export type RedisKey = [string, DataType]
 
 export const useFetchKeys = (search: SearchFilter) => {
-  const { redis } = useDatabrowser()
+  const { redisNoPipeline: redis } = useDatabrowser()
 
   const cache = useRef<PaginationCache | undefined>()
   const lastKey = useRef<string | undefined>()

--- a/src/components/databrowser/hooks/use-fetch-list-items.tsx
+++ b/src/components/databrowser/hooks/use-fetch-list-items.tsx
@@ -7,7 +7,7 @@ export const LIST_DISPLAY_PAGE_SIZE = 50
 export const FETCH_LIST_ITEMS_QUERY_KEY = "use-fetch-list-items"
 
 export const useFetchListItems = ({ dataKey, type }: { dataKey: string; type: ListDataType }) => {
-  const { redis } = useDatabrowser()
+  const { redisNoPipeline: redis } = useDatabrowser()
 
   const setQuery = useInfiniteQuery({
     enabled: type === "set",

--- a/src/components/databrowser/hooks/use-fetch-simple-key.tsx
+++ b/src/components/databrowser/hooks/use-fetch-simple-key.tsx
@@ -8,7 +8,7 @@ export const FETCH_SIMPLE_KEY_QUERY_KEY = "fetch-simple-key"
 
 /** Simple key standing for string or json */
 export const useFetchSimpleKey = (dataKey: string, type: DataType) => {
-  const { redis } = useDatabrowser()
+  const { redisNoPipeline: redis } = useDatabrowser()
   const { deleteKeyCache } = useDeleteKeyCache()
 
   return useQuery({

--- a/src/lib/clients.ts
+++ b/src/lib/clients.ts
@@ -4,9 +4,15 @@ import { Redis } from "@upstash/redis"
 
 import { toast } from "@/components/ui/use-toast"
 
-export const redisClient = (databrowser?: RedisCredentials) => {
-  const token = databrowser?.token || process.env.NEXT_PUBLIC_UPSTASH_REDIS_REST_TOKEN
-  const url = databrowser?.url || process.env.NEXT_PUBLIC_UPSTASH_REDIS_REST_URL
+export const redisClient = ({
+  credentials,
+  pipelining,
+}: {
+  credentials?: RedisCredentials
+  pipelining: boolean
+}) => {
+  const token = credentials?.token || process.env.NEXT_PUBLIC_UPSTASH_REDIS_REST_TOKEN
+  const url = credentials?.url || process.env.NEXT_PUBLIC_UPSTASH_REDIS_REST_URL
 
   if (!url) {
     throw new Error("Redis URL is missing!")
@@ -18,7 +24,7 @@ export const redisClient = (databrowser?: RedisCredentials) => {
   const redis = new Redis({
     url,
     token,
-    enableAutoPipelining: true,
+    enableAutoPipelining: pipelining,
     automaticDeserialization: false,
     keepAlive: false,
   })

--- a/src/store.tsx
+++ b/src/store.tsx
@@ -12,6 +12,7 @@ export type RedisCredentials = {
 
 type DatabrowserContextProps = {
   redis: Redis
+  redisNoPipeline: Redis
   store: ReturnType<typeof createDatabrowserStore>
 }
 
@@ -25,14 +26,15 @@ export const DatabrowserProvider = ({
   children,
   redisCredentials,
 }: PropsWithChildren<DatabrowserProviderProps>) => {
-  const redisInstance = useMemo(() => redisClient(redisCredentials), [redisCredentials])
+  const redisInstance = useMemo(() => redisClient({credentials: redisCredentials, pipelining: true}), [redisCredentials])
+  const redisInstanceNoPipeline = useMemo(() => redisClient({credentials: redisCredentials, pipelining: false}), [redisCredentials])
 
   const [store] = useState(() => {
     return createDatabrowserStore()
   })
 
   return (
-    <DatabrowserContext.Provider value={{ redis: redisInstance, store }}>
+    <DatabrowserContext.Provider value={{ redis: redisInstance, redisNoPipeline: redisInstanceNoPipeline, store }}>
       {children}
     </DatabrowserContext.Provider>
   )


### PR DESCRIPTION
Normally the auto pipelining feature in our redis client was enabled. This pr adds a `redisNoPipeline` client too so we can opt out of pipelinening wherenever we want

Sometimes a long running request can block other requests in the pipeline. So for these usecases it makes sense to disable the auto pipeline feature