### PR TITLE
feat: Add fetching for exact match for faster results

### DIFF
--- a/src/components/databrowser/components/sidebar/index.tsx
+++ b/src/components/databrowser/components/sidebar/index.tsx
@@ -5,6 +5,7 @@ import { Button } from "@/components/ui/button"
 import { Spinner } from "@/components/ui/spinner"
 
 import { FETCH_LIST_ITEMS_QUERY_KEY, FETCH_SIMPLE_KEY_QUERY_KEY } from "../../hooks"
+import { FETCH_KEY_TYPE_QUERY_KEY } from "../../hooks/use-fetch-key-type"
 import { useKeys } from "../../hooks/use-keys"
 import { AddKeyModal } from "../add-key-modal"
 import { DisplayDbSize, FETCH_DB_SIZE_QUERY_KEY } from "./db-size"
@@ -37,6 +38,9 @@ export function Sidebar() {
                 })
                 queryClient.invalidateQueries({
                   queryKey: [FETCH_DB_SIZE_QUERY_KEY],
+                })
+                queryClient.invalidateQueries({
+                  queryKey: [FETCH_KEY_TYPE_QUERY_KEY],
                 })
               }}
             >

--- a/src/components/databrowser/components/sidebar/index.tsx
+++ b/src/components/databrowser/components/sidebar/index.tsx
@@ -62,9 +62,10 @@ export function Sidebar() {
         </div>
       </div>
 
-      {query.isLoading ? (
+      {query.isLoading && keys.length === 0 ? (
         <LoadingSkeleton />
       ) : keys.length > 0 ? (
+        // Infinite scroll already has a loader at the bottom
         <InfiniteScroll query={query}>
           <KeysList />
         </InfiniteScroll>

--- a/src/components/databrowser/components/sidebar/search-input.tsx
+++ b/src/components/databrowser/components/sidebar/search-input.tsx
@@ -29,7 +29,7 @@ export const SearchInput = () => {
         }}
         value={state}
       />
-      {search.key && (
+      {state && (
         <Button
           type="button"
           variant="link"
@@ -37,6 +37,7 @@ export const SearchInput = () => {
           className="absolute right-1 top-1/2 h-5 w-5 -translate-y-1/2 text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-100"
           onClick={() => {
             setSearchKey("")
+            setState("")
           }}
         >
           <IconX size={16} />

--- a/src/components/databrowser/hooks/use-delete-key-cache.ts
+++ b/src/components/databrowser/hooks/use-delete-key-cache.ts
@@ -3,6 +3,8 @@ import { useDatabrowserStore } from "@/store"
 
 import { queryClient } from "@/lib/clients"
 
+import { FETCH_KEY_TYPE_QUERY_KEY } from "./use-fetch-key-type"
+import { FETCH_LIST_ITEMS_QUERY_KEY } from "./use-fetch-list-items"
 import { FETCH_SIMPLE_KEY_QUERY_KEY } from "./use-fetch-simple-key"
 import { FETCH_KEYS_QUERY_KEY, useKeys } from "./use-keys"
 
@@ -18,6 +20,12 @@ export const useDeleteKeyCache = () => {
       })
       queryClient.invalidateQueries({
         queryKey: [FETCH_SIMPLE_KEY_QUERY_KEY, key],
+      })
+      queryClient.invalidateQueries({
+        queryKey: [FETCH_LIST_ITEMS_QUERY_KEY, key],
+      })
+      queryClient.invalidateQueries({
+        queryKey: [FETCH_KEY_TYPE_QUERY_KEY, key],
       })
       refetch()
     },

--- a/src/components/databrowser/hooks/use-fetch-key-type.tsx
+++ b/src/components/databrowser/hooks/use-fetch-key-type.tsx
@@ -1,0 +1,17 @@
+import { useDatabrowser } from "@/store"
+import { useQuery } from "@tanstack/react-query"
+
+export const FETCH_KEY_TYPE_QUERY_KEY = "fetch-key-type"
+
+export const useFetchKeyType = (key: string | undefined) => {
+  const { redisNoPipeline: redis } = useDatabrowser()
+
+  return useQuery({
+    queryKey: [FETCH_KEY_TYPE_QUERY_KEY, key],
+    queryFn: async () => {
+      if (!key) return "none"
+
+      return await redis.type(key)
+    },
+  })
+}

--- a/src/components/databrowser/hooks/use-keys.tsx
+++ b/src/components/databrowser/hooks/use-keys.tsx
@@ -25,6 +25,9 @@ export const FETCH_KEYS_QUERY_KEY = "use-fetch-keys"
 
 export const KeysProvider = ({ children }: PropsWithChildren) => {
   const { search } = useDatabrowserStore()
+  const cleanSearchKey = search.key.replace("*", "")
+
+  const { data: exactMatchType } = useFetchKeyType(cleanSearchKey)
 
   const { fetchKeys, resetCache } = useFetchKeys(search)
   const pageRef = useRef(0)
@@ -51,10 +54,6 @@ export const KeysProvider = ({ children }: PropsWithChildren) => {
     resetCache()
     query.refetch()
   }, [query, resetCache])
-
-  const cleanSearchKey = search.key.replace("*", "")
-
-  const { data: exactMatchType } = useFetchKeyType(cleanSearchKey)
 
   const keys = useMemo(() => {
     const keys = query.data?.pages.flatMap((page) => page.keys) ?? []


### PR DESCRIPTION
- Sends a parallel `TYPE` request with the other scan requests to check for an exact match. If exact match is found, it is displayed without waiting for the other commands to finish.