### PR TITLE
DX-1875: wait for type request to finish before sending scans

### DIFF
--- a/src/components/databrowser/hooks/use-keys.tsx
+++ b/src/components/databrowser/hooks/use-keys.tsx
@@ -27,7 +27,7 @@ export const KeysProvider = ({ children }: PropsWithChildren) => {
   const { search } = useDatabrowserStore()
   const cleanSearchKey = search.key.replace("*", "")
 
-  const { data: exactMatchType } = useFetchKeyType(cleanSearchKey)
+  const { data: exactMatchType, isFetching } = useFetchKeyType(cleanSearchKey)
 
   const { fetchKeys, resetCache } = useFetchKeys(search)
   const pageRef = useRef(0)
@@ -47,6 +47,7 @@ export const KeysProvider = ({ children }: PropsWithChildren) => {
     getNextPageParam: (lastPage, __, lastPageIndex) => {
       return lastPage.hasNextPage ? lastPageIndex + 1 : undefined
     },
+    enabled: !isFetching,
     refetchOnMount: false,
   })
 


### PR DESCRIPTION
Because we were sending the single type request parallel with the scan requests, any of the requests could reach the server first. This meant that the scan requests could still slow down the type request.

With this change, we only allow scan requests if single type request isn't on flight.