### PR TITLE
DX-2474: use SEARCH.LISTINDEXES for listing search indexes

### DIFF
--- a/scripts/create-test-indexes.ts
+++ b/scripts/create-test-indexes.ts
@@ -1,0 +1,26 @@
+/* eslint-disable no-console */
+import { Redis } from "@upstash/redis"
+
+const redis = new Redis({
+  url: process.env.UPSTASH_REDIS_REST_URL!,
+  token: process.env.UPSTASH_REDIS_REST_TOKEN!,
+})
+
+const COUNT = 200
+
+for (let i = 1; i <= COUNT; i++) {
+  const name = `test-index-${String(i).padStart(3, "0")}`
+  try {
+    await redis.search.createIndex({
+      name,
+      dataType: "hash",
+      prefix: [`${name}:`],
+      schema: { title: "TEXT" },
+    })
+    console.log(`[${i}/${COUNT}] created ${name}`)
+  } catch (error) {
+    console.error(`[${i}/${COUNT}] failed ${name}:`, error)
+  }
+}
+
+console.log("done")

--- a/src/components/databrowser/components/header/index.tsx
+++ b/src/components/databrowser/components/header/index.tsx
@@ -4,6 +4,7 @@ import {
   IconChevronDown,
   IconCircleCheck,
   IconCirclePlus,
+  IconLoader2,
   IconPlus,
   IconSearch,
   IconSparkles,
@@ -16,6 +17,7 @@ import { Segmented } from "@/components/ui/segmented"
 import { SimpleTooltip } from "@/components/ui/tooltip"
 
 import type { TabType } from "../.."
+import { useDebounce } from "../../hooks/use-debounce"
 import { useFetchSearchIndexes } from "../../hooks/use-fetch-search-indexes"
 import { AddKeyModal } from "../add-key-modal"
 import { QueryWizardPopover } from "../query-wizard/query-wizard-popover"
@@ -85,22 +87,29 @@ const IndexSelector = () => {
     valuesSearch: { index },
     setValuesSearchIndex,
   } = useTab()
-  const { data: indexes, isLoading } = useFetchSearchIndexes()
   const [open, setOpen] = useState(false)
+  const [search, setSearch] = useState("")
+  const debouncedSearch = useDebounce(search, 150)
+  const match = debouncedSearch ? `${debouncedSearch}*` : undefined
+
+  const {
+    data: indexes,
+    isLoading,
+    hasNextPage,
+    fetchNextPage,
+    isFetchingNextPage,
+  } = useFetchSearchIndexes({ match })
+  const [editingIndex, setEditingIndex] = useState<string | undefined>()
 
   // Auto-select first index if none is selected, or clear if selected index no longer exists
   useEffect(() => {
-    if (!indexes || isLoading) return
+    if (!indexes || isLoading || debouncedSearch) return
     if (index && !indexes.includes(index)) {
       setValuesSearchIndex("")
     } else if (!index && indexes.length > 0) {
       setValuesSearchIndex(indexes[0])
     }
-  }, [indexes, index, isLoading, setValuesSearchIndex])
-  const [search, setSearch] = useState("")
-  const [editingIndex, setEditingIndex] = useState<string | undefined>()
-
-  const filteredIndexes = indexes?.filter((idx) => idx.toLowerCase().includes(search.toLowerCase()))
+  }, [indexes, index, isLoading, setValuesSearchIndex, debouncedSearch])
 
   const handleEditIndex = (indexName: string) => {
     setOpen(false)
@@ -145,10 +154,15 @@ const IndexSelector = () => {
 
             {/* Index list */}
             <div className="max-h-[200px] overflow-y-auto">
-              {filteredIndexes?.length === 0 && (
+              {isLoading && !indexes && (
+                <div className="flex items-center justify-center py-4">
+                  <IconLoader2 className="size-4 animate-spin text-zinc-400" />
+                </div>
+              )}
+              {!isLoading && indexes?.length === 0 && (
                 <div className="py-4 text-center text-sm text-zinc-500">No indexes found</div>
               )}
-              {filteredIndexes?.map((idx) => (
+              {indexes?.map((idx) => (
                 <div
                   key={idx}
                   className="flex h-9 items-center rounded-md px-2 transition-colors hover:bg-zinc-100 dark:hover:bg-zinc-200"
@@ -182,6 +196,16 @@ const IndexSelector = () => {
                   </button>
                 </div>
               ))}
+
+              {hasNextPage && (
+                <button
+                  onClick={() => fetchNextPage()}
+                  disabled={isFetchingNextPage}
+                  className="flex h-9 w-full items-center justify-center rounded-md text-sm text-emerald-600 transition-colors hover:bg-zinc-100 disabled:opacity-50"
+                >
+                  {isFetchingNextPage ? "Loading..." : "Load more"}
+                </button>
+              )}
             </div>
           </div>
         </PopoverContent>

--- a/src/components/databrowser/hooks/use-fetch-search-indexes.tsx
+++ b/src/components/databrowser/hooks/use-fetch-search-indexes.tsx
@@ -1,9 +1,26 @@
 import { useRedis } from "@/redis-context"
 import { useQuery } from "@tanstack/react-query"
 
-import { scanKeys } from "@/lib/scan-keys"
-
 export const FETCH_SEARCH_INDEXES_QUERY_KEY = "fetch-search-indexes"
+
+// Parses the SEARCH.LISTINDEXES response into an array of index names.
+// Response format: [["name", "idx1", "type", "STRING"], ["name", "idx2", "type", "STRING"], ...]
+export function parseListIndexesResponse(result: string[][] | string[]): string[] {
+  if (result.length === 0) return []
+
+  // Nested array format: each entry is ["name", "<name>", "type", "<type>"]
+  if (Array.isArray(result[0])) {
+    return (result as string[][]).map((entry) => entry[1])
+  }
+
+  // Flat format fallback: ["name", "idx1", "type", "STRING", ...]
+  const names: string[] = []
+  const flat = result as string[]
+  for (let i = 0; i + 1 < flat.length; i += 4) {
+    if (flat[i] === "name") names.push(flat[i + 1])
+  }
+  return names
+}
 
 export const useFetchSearchIndexes = ({
   match,
@@ -14,6 +31,25 @@ export const useFetchSearchIndexes = ({
   return useQuery({
     queryKey: [FETCH_SEARCH_INDEXES_QUERY_KEY],
     enabled: enabled ?? true,
-    queryFn: () => scanKeys(redis, { match, type: "search" }),
+    queryFn: async () => {
+      const LIMIT = 100
+      let offset = 0
+      const allNames: string[] = []
+
+      while (true) {
+        const args: string[] = ["search.listindexes"]
+        if (match) args.push("MATCH", match)
+        args.push("LIMIT", String(LIMIT), "OFFSET", String(offset))
+
+        const result = await redis.exec<string[][]>(args as [string, ...string[]])
+        const names = parseListIndexesResponse(result)
+        allNames.push(...names)
+
+        if (names.length < LIMIT) break
+        offset += names.length
+      }
+
+      return allNames
+    },
   })
 }

--- a/src/components/databrowser/hooks/use-fetch-search-indexes.tsx
+++ b/src/components/databrowser/hooks/use-fetch-search-indexes.tsx
@@ -1,26 +1,11 @@
 import { useRedis } from "@/redis-context"
-import { useQuery } from "@tanstack/react-query"
+import { useInfiniteQuery } from "@tanstack/react-query"
+
+import { listSearchIndexes } from "@/lib/list-search-indexes"
 
 export const FETCH_SEARCH_INDEXES_QUERY_KEY = "fetch-search-indexes"
 
-// Parses the SEARCH.LISTINDEXES response into an array of index names.
-// Response format: [["name", "idx1", "type", "STRING"], ["name", "idx2", "type", "STRING"], ...]
-export function parseListIndexesResponse(result: string[][] | string[]): string[] {
-  if (result.length === 0) return []
-
-  // Nested array format: each entry is ["name", "<name>", "type", "<type>"]
-  if (Array.isArray(result[0])) {
-    return (result as string[][]).map((entry) => entry[1])
-  }
-
-  // Flat format fallback: ["name", "idx1", "type", "STRING", ...]
-  const names: string[] = []
-  const flat = result as string[]
-  for (let i = 0; i + 1 < flat.length; i += 4) {
-    if (flat[i] === "name") names.push(flat[i + 1])
-  }
-  return names
-}
+const PAGE_SIZE = 30
 
 export const useFetchSearchIndexes = ({
   match,
@@ -28,28 +13,27 @@ export const useFetchSearchIndexes = ({
 }: { match?: string; enabled?: boolean } = {}) => {
   const { redisNoPipeline: redis } = useRedis()
 
-  return useQuery({
-    queryKey: [FETCH_SEARCH_INDEXES_QUERY_KEY],
+  const query = useInfiniteQuery({
+    queryKey: [FETCH_SEARCH_INDEXES_QUERY_KEY, match],
     enabled: enabled ?? true,
-    queryFn: async () => {
-      const LIMIT = 100
-      let offset = 0
-      const allNames: string[] = []
-
-      while (true) {
-        const args: string[] = ["search.listindexes"]
-        if (match) args.push("MATCH", match)
-        args.push("LIMIT", String(LIMIT), "OFFSET", String(offset))
-
-        const result = await redis.exec<string[][]>(args as [string, ...string[]])
-        const names = parseListIndexesResponse(result)
-        allNames.push(...names)
-
-        if (names.length < LIMIT) break
-        offset += names.length
+    initialPageParam: 0,
+    queryFn: async ({ pageParam: offset }) => {
+      const names = await listSearchIndexes(redis, { match, limit: PAGE_SIZE, offset })
+      return {
+        names,
+        nextOffset: names.length >= PAGE_SIZE ? offset + names.length : undefined,
       }
-
-      return allNames
     },
+    getNextPageParam: (lastPage) => lastPage.nextOffset,
   })
+
+  const indexes = query.data?.pages.flatMap((page) => page.names)
+
+  return {
+    data: indexes,
+    isLoading: query.isLoading || (query.isFetching && !query.isFetchingNextPage),
+    hasNextPage: query.hasNextPage,
+    fetchNextPage: query.fetchNextPage,
+    isFetchingNextPage: query.isFetchingNextPage,
+  }
 }

--- a/src/components/databrowser/hooks/use-keys.tsx
+++ b/src/components/databrowser/hooks/use-keys.tsx
@@ -9,6 +9,7 @@ import { parseJSObjectLiteral } from "@/lib/utils"
 
 import { FETCH_KEY_TYPE_QUERY_KEY } from "./use-fetch-key-type"
 import { useFetchSearchIndex } from "./use-fetch-search-index"
+import { parseListIndexesResponse } from "./use-fetch-search-indexes"
 
 const KeysContext = createContext<
   | {
@@ -80,6 +81,30 @@ export const KeysProvider = ({ children }: PropsWithChildren) => {
     return { cursor: newCursor, keys }
   }
 
+  // Redis search index scan — used when the type filter is "search"
+  const redisSearchIndexScan = async ({
+    count,
+    cursor,
+  }: {
+    count: number
+    cursor: string
+  }): Promise<ScanResult> => {
+    const offset = Number.parseInt(cursor, 10) || 0
+
+    const args: string[] = ["search.listindexes"]
+    if (search.key) args.push("MATCH", search.key)
+    args.push("LIMIT", String(count), "OFFSET", String(offset))
+
+    const result = await redis.exec<string[][]>(args as [string, ...string[]])
+    const names = parseListIndexesResponse(result)
+    const keys = names.map((name) => ({ key: name, type: "search" as DataType }))
+
+    const hasMore = keys.length >= count
+    const nextCursor = hasMore ? String(offset + keys.length) : "0"
+
+    return { cursor: nextCursor, keys }
+  }
+
   // Redis search value scan
   const redisValueScan = async ({
     count,
@@ -118,7 +143,11 @@ export const KeysProvider = ({ children }: PropsWithChildren) => {
   }
 
   const performScan = async (count: number, cursor: string) => {
-    const scanFunction = isValuesSearchSelected ? redisValueScan : redisKeyScan
+    const scanFunction = isValuesSearchSelected
+      ? redisValueScan
+      : search.type === "search"
+        ? redisSearchIndexScan
+        : redisKeyScan
 
     const result = await scanFunction({ count, cursor })
     return [result.cursor, result.keys] as const

--- a/src/components/databrowser/hooks/use-keys.tsx
+++ b/src/components/databrowser/hooks/use-keys.tsx
@@ -5,11 +5,11 @@ import type { DataType, RedisKey } from "@/types"
 import { useInfiniteQuery, type UseInfiniteQueryResult } from "@tanstack/react-query"
 
 import { queryClient } from "@/lib/clients"
+import { listSearchIndexes } from "@/lib/list-search-indexes"
 import { parseJSObjectLiteral } from "@/lib/utils"
 
 import { FETCH_KEY_TYPE_QUERY_KEY } from "./use-fetch-key-type"
 import { useFetchSearchIndex } from "./use-fetch-search-index"
-import { parseListIndexesResponse } from "./use-fetch-search-indexes"
 
 const KeysContext = createContext<
   | {
@@ -91,12 +91,11 @@ export const KeysProvider = ({ children }: PropsWithChildren) => {
   }): Promise<ScanResult> => {
     const offset = Number.parseInt(cursor, 10) || 0
 
-    const args: string[] = ["search.listindexes"]
-    if (search.key) args.push("MATCH", search.key)
-    args.push("LIMIT", String(count), "OFFSET", String(offset))
-
-    const result = await redis.exec<string[][]>(args as [string, ...string[]])
-    const names = parseListIndexesResponse(result)
+    const names = await listSearchIndexes(redis, {
+      match: search.key || undefined,
+      limit: count,
+      offset,
+    })
     const keys = names.map((name) => ({ key: name, type: "search" as DataType }))
 
     const hasMore = keys.length >= count

--- a/src/lib/list-search-indexes.ts
+++ b/src/lib/list-search-indexes.ts
@@ -1,0 +1,53 @@
+import type { Redis } from "@upstash/redis"
+
+/**
+ * Lists search indexes using the SEARCH.LISTINDEXES command.
+ * Supports pagination via LIMIT/OFFSET and optional MATCH filtering.
+ */
+export async function listSearchIndexes(
+  redis: Redis,
+  {
+    match,
+    limit,
+    offset = 0,
+  }: {
+    match?: string
+    limit: number
+    offset?: number
+  }
+): Promise<string[]> {
+  const args: string[] = ["search.listindexes"]
+  if (match) args.push("MATCH", match)
+  args.push("LIMIT", String(limit), "OFFSET", String(offset))
+
+  const result = await redis.exec<string[][]>(args as [string, ...string[]])
+  return parseListIndexesResponse(result)
+}
+
+/**
+ * Collects all search indexes by paginating through SEARCH.LISTINDEXES.
+ */
+export async function listAllSearchIndexes(
+  redis: Redis,
+  { match }: { match?: string } = {}
+): Promise<string[]> {
+  const PAGE_SIZE = 100
+  let offset = 0
+  const allNames: string[] = []
+
+  while (true) {
+    const names = await listSearchIndexes(redis, { match, limit: PAGE_SIZE, offset })
+    allNames.push(...names)
+
+    if (names.length < PAGE_SIZE) break
+    offset += names.length
+  }
+
+  return allNames
+}
+
+// Parses the SEARCH.LISTINDEXES response into an array of index names.
+// Response format: [["name", "idx1", "type", "STRING"], ...]
+function parseListIndexesResponse(result: string[][]): string[] {
+  return result.map((entry) => entry[1])
+}


### PR DESCRIPTION
## Summary
- Replace SCAN-based approach with the dedicated `SEARCH.LISTINDEXES` command via a new `listSearchIndexes` utility in `src/lib/list-search-indexes.ts`
- Index selector dropdown now paginates (30 per page) with a "Load more" button instead of rendering all indexes at once
- Search input in the index selector filters server-side using the MATCH parameter with debouncing, instead of filtering in-memory