### PR TITLE
DX-2609: fix: close delete confirmation modal after successful deletion

### DIFF
--- a/src/components/databrowser/components/delete-key-modal.tsx
+++ b/src/components/databrowser/components/delete-key-modal.tsx
@@ -105,6 +105,7 @@ export function DeleteKeyModal({
               setIsPending(true)
               try {
                 await onDeleteConfirm(e, { reindex })
+                setIsOpen?.(false)
               } finally {
                 setIsPending(false)
               }


### PR DESCRIPTION
Fixes [DX-2609](https://linear.app/upstash/issue/DX-2609/databrowser-list-delete-action-does-not-close-the-modal): in the Data Browser, deleting a list item left the confirmation popup open, letting users keep clicking **Delete** and silently delete subsequent items.

Root cause: `DeleteKeyModal` did not close itself after `onDeleteConfirm` resolved. The three callsites that use it in uncontrolled mode (`display-list.tsx` per-row trash, `item-actions.tsx` dropdown, `key-actions.tsx` dropdown) had no way to dismiss the dialog.

Fix: call `setIsOpen?.(false)` after a successful `onDeleteConfirm` in `delete-key-modal.tsx`. Stays inside the `try` so a failed mutation keeps the modal open for retry. The two controlled callsites (`sidebar-context-menu.tsx`, `item-context-menu.tsx`) already close manually — those calls become redundant but are harmless.