### PR TITLE
DX-2542: fix: show two units of detail in TTL formatter

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -55,8 +55,7 @@ export function formatTime(seconds: number) {
     parts.push("0s")
   }
 
-  // Just get the first part because of design change
-  return parts.slice(0, 1).join(" ")
+  return parts.slice(0, 2).join(" ")
 }
 
 export const isTest = typeof window !== "undefined" && (window as any).__PLAYWRIGHT__ === true


### PR DESCRIPTION
TTL of 5,224,972s (~60.4 days) was rendered as `1 month`, dropping the rest. Now shows two units, e.g. `1 month 30d`.

<img width="209" height="97" alt="image" src="https://github.com/user-attachments/assets/237ea17d-b5b8-4425-b7f0-758df1a65c73" />
