### PR TITLE
fix: convert hash index sample data to object in query wizard

### DIFF
--- a/src/components/databrowser/components/query-wizard/query-wizard-popover.tsx
+++ b/src/components/databrowser/components/query-wizard/query-wizard-popover.tsx
@@ -42,7 +42,13 @@ export const QueryWizardPopover = ({ onClose }: { onClose?: () => void }) => {
             const data = await redis.json.get(key)
             return { key, data }
           } else if (index.dataType === "hash") {
-            const data = await redis.hgetall(key)
+            const raw = (await redis.hgetall(key)) as unknown
+            const data = Array.isArray(raw)
+              ? raw.reduce<Record<string, unknown>>((obj, value, i, arr) => {
+                  if (i % 2 === 0) obj[String(value)] = arr[i + 1]
+                  return obj
+                }, {})
+              : raw
             return { key, data }
           } else {
             const data = await redis.get(key)


### PR DESCRIPTION
The AI Query Builder sends a few sample documents from the index to the LLM as context. For hash indexes, `hgetall` returns a raw flat array (`["title", "My doc"]`) instead of an object, because the client runs with `automaticDeserialization: false` — which caused the wizard to fail with `Invalid request data`.

This converts the flat array into a `{ field: value }` object before sending, so hash indexes work and the LLM gets cleaner data. JSON and string indexes were unaffected since they come back as strings.