### PR TITLE
fix: isolate root stacking context so internal z-indexes stay inside the browser

### DIFF
--- a/src/components/databrowser/index.tsx
+++ b/src/components/databrowser/index.tsx
@@ -190,7 +190,10 @@ const RedisBrowserRoot = ({
     /* ups-db is the custom class used to prefix every style in the css bundle */
     <div
       className={`ups-db ${theme === "dark" ? "dark" : ""}`}
-      style={{ height: "100%" }}
+      // isolation keeps internal z-indexes (tab scroll shadows, dragged tabs) from stacking above
+      // the host page's own positioned elements, e.g. the console's sticky navbar. Inline because
+      // prefixed css classes only match descendants of .ups-db, not the root itself.
+      style={{ height: "100%", isolation: "isolate" }}
       ref={rootRef}
     >
       <div className="flex h-full flex-col rounded-[14px] border-[4px] border-zinc-300 text-zinc-700">

--- a/src/playground/index.tsx
+++ b/src/playground/index.tsx
@@ -31,6 +31,9 @@ const App = () => {
 
   return (
     <main
+      // The css bundle prefixes every selector with .ups-db, so the playground shell
+      // (credentials form) only gets its tailwind styles inside this scope
+      className={`ups-db ${theme === "dark" ? "dark" : ""}`}
       style={{
         position: "fixed",
         inset: 0,


### PR DESCRIPTION
Tab scroll shadows (z-10) and dragged tabs (z-50) stacked above the embedding page's own elements, like the console's sticky navbar on database details. Adding `isolation: isolate` on the root element contains every internal z-index. Portaled overlays (dialogs, popovers, toasts) are unaffected since they render outside the root.

Also scopes the playground shell under `ups-db` so the credentials form is styled on Vercel previews: every selector in the css bundle is prefixed with `.ups-db`, and the form rendered outside of it, showing up completely unstyled.

Reproduced with an overflowing tab strip and a console-style sticky navbar (z-10) overlapping the tab bar:

![before](https://gist.githubusercontent.com/ytkimirti/f3748d40f6524a504a51586dabce3367/raw/before.png)

![after](https://gist.githubusercontent.com/ytkimirti/f3748d40f6524a504a51586dabce3367/raw/after.png)
