### PR TITLE
fix: prevent setState-during-render in search query builder

### DIFF
--- a/src/components/databrowser/components/ui-query-builder/use-query-state-sync.ts
+++ b/src/components/databrowser/components/ui-query-builder/use-query-state-sync.ts
@@ -21,6 +21,11 @@ export const useQueryStateSync = () => {
   const lastSyncedQuery = useRef<string>(valuesSearch.query)
   const isOurUpdate = useRef(false)
 
+  // Mirror of the latest state so setQueryState can compute the next state without
+  // running side effects inside the useState updater (which executes during render).
+  const queryStateRef = useRef(queryState)
+  queryStateRef.current = queryState
+
   // Sync FROM zustand only when it changes from an external source
   useEffect(() => {
     // If this change was caused by us, skip re-parsing
@@ -40,20 +45,20 @@ export const useQueryStateSync = () => {
     }
   }, [valuesSearch.query])
 
-  // Setter that applies changes locally and syncs to zustand
+  // Setter that applies changes locally and syncs to zustand.
+  // The zustand write runs here in the caller's context (event handler / effect), not
+  // inside the useState updater, so it never fires during another component's render.
   const setQueryState = useCallback(
     (modifier: (state: QueryState) => QueryState) => {
-      setQueryStateInternal((currentState) => {
-        const newState = modifier(structuredClone(currentState))
+      const newState = modifier(structuredClone(queryStateRef.current))
+      queryStateRef.current = newState
 
-        // Sync to zustand
-        const newQueryString = stringifyQueryState(newState)
-        isOurUpdate.current = true
-        lastSyncedQuery.current = newQueryString
-        setValuesSearchQuery(newQueryString)
+      const newQueryString = stringifyQueryState(newState)
+      isOurUpdate.current = true
+      lastSyncedQuery.current = newQueryString
 
-        return newState
-      })
+      setQueryStateInternal(newState)
+      setValuesSearchQuery(newQueryString)
     },
     [setValuesSearchQuery]
   )


### PR DESCRIPTION
## Problem

Opening the search Query Builder logs a React console error on every mount:

```
Cannot update a component (Tab) while rendering a different component (UIQueryBuilder).
```

## Cause

`useQueryStateSync`'s `setQueryState` calls `setValuesSearchQuery` (a zustand setter) inside the `setQueryStateInternal` updater. State updater functions run during React's render phase, so the store write synchronously notifies a sibling tab-bar subscriber (`Tab` / `AddTabButton`) while `UIQueryBuilder` is still rendering. It fires reliably because the normalize-on-mount effect calls `setQueryState` as soon as the builder mounts against an index schema.

## Fix

Track the latest query state in a ref, compute the next state from it, and run both the local `setState` and the zustand write in the caller's context (event handler / effect) instead of inside the updater. The store write stays synchronous and behavior is otherwise unchanged.